### PR TITLE
Replace gradle snapshots version with release version to avoid download fail

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220806221607+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi @GavinRay97, thank you very much for open sourcing the calcite-online project, it will be very helpful for beginners of calcite. When I execute `./gradlew build`, it prompts that gradle download failed. I found that the snapshots version in the code could no longer be downloaded. It might be better to replace it with the release version, so I submitted this PR.